### PR TITLE
Fix remove_admin parameter

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -331,7 +331,7 @@ def add_admin(channel_id, new_admin_username, requester_username):
     conn.close()
     return False
 
-def remove_admin(channel_id, admin_username348, requester_username):
+def remove_admin(channel_id, admin_username, requester_username):
     conn = sqlite3.connect(DB_FILE)
     c = conn.cursor()
     c.execute("SELECT username FROM admins WHERE channel_id = ? AND username = ?", (channel_id, requester_username))


### PR DESCRIPTION
## Summary
- rename `admin_username348` parameter to `admin_username`
- keep `remove_admin` call passing the username to remove

## Testing
- `python -m py_compile bot.py`

------
https://chatgpt.com/codex/tasks/task_e_68446c526774832abb97bdab8a90a13e