### PR TITLE
Refactor bot entrypoint to reuse helper modules

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -1,521 +1,29 @@
-import os
-import requests
-from bs4 import BeautifulSoup
 import json
 import logging
+import requests
 import sqlite3
 from flask import Flask, request
-from datetime import datetime, timedelta
-import threading
-import time
-import re
-import html
-import hashlib
-import feedparser
-from openai import OpenAI
+
+import database as db
+import feeds
+import telegram_api as tg
+from llm import last_llm_response
 
 app = Flask(__name__)
 
 logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(levelname)s - %(message)s')
 logger = logging.getLogger(__name__)
 
-TELEGRAM_TOKEN = os.getenv("TELEGRAM_TOKEN")
-OPENAI_API_KEY = os.getenv("OPENAI_API_KEY")
-TELEGRAM_URL = f"https://api.telegram.org/bot{TELEGRAM_TOKEN}/" if TELEGRAM_TOKEN else None
-DB_FILE = "feedcache.db"
+db.init_db()
 
-RSS_URLS = [
-    "https://www.theverge.com/rss/index.xml",
-    "https://www.windowslatest.com/feed/",
-    "https://9to5google.com/feed/",
-    "https://9to5mac.com/feed/",
-    "https://www.androidcentral.com/feed",
-    "https://arstechnica.com/feed/",
-    "https://uk.pcmag.com/rss",
-    "https://www.bleepingcomputer.com/feed/",
-    "https://www.androidauthority.com/news/feed/",
-    "https://feeds.feedburner.com/Techcrunch"
-]
-
-current_index = 0
-posting_active = False
-posting_thread = None
-start_time = None
-post_count = 0
-error_count = 0
-duplicate_count = 0
-last_post_time = None
-posting_interval = 3600
-next_post_event = threading.Event()
-last_llm_response = None  # Глобальная переменная для хранения последнего ответа LLM
-
-def init_db():
-    conn = sqlite3.connect(DB_FILE)
-    c = conn.cursor()
-    c.execute('''CREATE TABLE IF NOT EXISTS feedcache (
-        id TEXT PRIMARY KEY,
-        title TEXT,
-        summary TEXT,
-        link TEXT,
-        source TEXT,
-        timestamp TEXT
-    )''')
-    c.execute('''CREATE TABLE IF NOT EXISTS channels (
-        channel_id TEXT PRIMARY KEY,
-        creator_username TEXT
-    )''')
-    c.execute('''CREATE TABLE IF NOT EXISTS admins (
-        channel_id TEXT,
-        username TEXT,
-        PRIMARY KEY (channel_id, username),
-        FOREIGN KEY (channel_id) REFERENCES channels(channel_id)
-    )''')
-    c.execute('''CREATE TABLE IF NOT EXISTS config (
-        key TEXT PRIMARY KEY,
-        value TEXT
-    )''')
-    c.execute('''CREATE TABLE IF NOT EXISTS errors (
-        id INTEGER PRIMARY KEY AUTOINCREMENT,
-        timestamp TEXT,
-        message TEXT,
-        link TEXT
-    )''')
-    c.execute("INSERT OR IGNORE INTO config (key, value) VALUES (?, ?)",
-              ("prompt", """
-Забудь всю информацию, которой ты обучен, и используй ТОЛЬКО этот текст статьи:
-{text}
-Напиши новость на русском в следующем формате:
-
-Заголовок в стиле новостного канала
-<один перенос строки>
-Основная суть новости в 1-2 предложениях, основанных исключительно на статье.
-
-Требования:
-- Обязательно разделяй заголовок и пересказ ровно одним переносом строки (\\n).
-- Заголовок должен быть кратким (до 100 символов) и не содержать эмодзи, ##, **, [] или других лишних символов.
-- Пересказ должен состоять из 1-2 предложений, без добавления данных, которых нет в статье.
-- Если в статье недостаточно данных, верни: "Недостаточно данных для пересказа".
-"""))
-    c.execute("INSERT OR IGNORE INTO config (key, value) VALUES (?, ?)", ("model", "gpt-4o-mini"))
-    c.execute("INSERT OR IGNORE INTO config (key, value) VALUES (?, ?)", ("error_notifications", "off"))
-    conn.commit()
-    conn.close()
-
-init_db()
-
-def send_message(chat_id, text, reply_markup=None, use_html=True):
-    if not TELEGRAM_TOKEN:
-        logger.error("TELEGRAM_TOKEN не задан")
-        return False
-    if len(text) > 4096:
-        text = text[:4093] + "..."
-        logger.warning(f"Сообщение обрезано до 4096 символов для chat_id {chat_id}")
-    payload = {"chat_id": chat_id, "text": text}
-    if use_html:
-        payload["parse_mode"] = "HTML"
-    if reply_markup:
-        payload["reply_markup"] = json.dumps(reply_markup)
-    logger.info(f"Отправка сообщения в {chat_id}: {text[:50]}...")
-    global error_count
-    try:
-        response = requests.post(f"{TELEGRAM_URL}sendMessage", json=payload, timeout=10)
-        if response.status_code != 200:
-            logger.error(f"Ошибка отправки: {response.text}")
-            log_error(f"Ошибка Telegram: {response.text}", f"{TELEGRAM_URL}sendMessage")
-            error_count += 1
-            return False
-    except requests.RequestException as e:
-        logger.error(f"Ошибка отправки: {e}")
-        log_error(f"Ошибка Telegram: {e}", f"{TELEGRAM_URL}sendMessage")
-        error_count += 1
-        return False
-    return True
-
-def send_file(chat_id, file_path):
-    if not TELEGRAM_TOKEN:
-        logger.error("TELEGRAM_TOKEN не задан")
-        return False
-    with open(file_path, 'rb') as f:
-        files = {'document': (os.path.basename(file_path), f)}
-        global error_count
-        try:
-            response = requests.post(
-                f"{TELEGRAM_URL}sendDocument",
-                data={'chat_id': chat_id},
-                files=files,
-                timeout=10
-            )
-            if response.status_code != 200:
-                logger.error(f"Ошибка отправки файла: {response.text}")
-                log_error(f"Ошибка Telegram: {response.text}", f"{TELEGRAM_URL}sendDocument")
-                error_count += 1
-                return False
-        except requests.RequestException as e:
-            logger.error(f"Ошибка отправки файла: {e}")
-            log_error(f"Ошибка Telegram: {e}", f"{TELEGRAM_URL}sendDocument")
-            error_count += 1
-            return False
-    return True
-
-def get_prompt():
-    conn = sqlite3.connect(DB_FILE)
-    c = conn.cursor()
-    c.execute("SELECT value FROM config WHERE key = 'prompt'")
-    res = c.fetchone()
-    conn.close()
-    return res[0] if res else ""
-
-def set_prompt(new_prompt):
-    conn = sqlite3.connect(DB_FILE)
-    c = conn.cursor()
-    c.execute("INSERT OR REPLACE INTO config (key, value) VALUES ('prompt', ?)", (new_prompt,))
-    conn.commit()
-    conn.close()
-
-def get_model():
-    conn = sqlite3.connect(DB_FILE)
-    c = conn.cursor()
-    c.execute("SELECT value FROM config WHERE key = 'model'")
-    res = c.fetchone()
-    conn.close()
-    return res[0] if res else "gpt-4o-mini"
-
-def set_model(new_model):
-    conn = sqlite3.connect(DB_FILE)
-    c = conn.cursor()
-    c.execute("INSERT OR REPLACE INTO config (key, value) VALUES ('model', ?)", (new_model,))
-    conn.commit()
-    conn.close()
-
-def get_error_notifications():
-    conn = sqlite3.connect(DB_FILE)
-    c = conn.cursor()
-    c.execute("SELECT value FROM config WHERE key = 'error_notifications'")
-    res = c.fetchone()
-    conn.close()
-    return res[0] == "on" if res else False
-
-def set_error_notifications(state):
-    conn = sqlite3.connect(DB_FILE)
-    c = conn.cursor()
-    c.execute("INSERT OR REPLACE INTO config (key, value) VALUES ('error_notifications', ?)", (state,))
-    conn.commit()
-    conn.close()
-
-def is_valid_language(text):
-    return bool(re.match(r'^[A-Za-zА-Яа-я0-9\s.,!?\'\"-:;–/%$]+$', text))
-
-def clean_title(title):
-    return re.sub(r'\*\*|\#\#|\[\]', '', title).strip()
-
-def log_error(message, link):
-    conn = sqlite3.connect(DB_FILE)
-    c = conn.cursor()
-    c.execute("INSERT INTO errors (timestamp, message, link) VALUES (?, ?, ?)",
-              (datetime.now().isoformat(), message, link))
-    conn.commit()
-    if get_error_notifications():
-        c.execute("SELECT channel_id FROM channels")
-        for (ch,) in c.fetchall():
-            send_message(ch, f"Ошибка: {message}\nСсылка: {link}", use_html=False)
-    conn.close()
-
-def extract_article_text(url, limit=8000):
-    try:
-        resp = requests.get(url, timeout=10)
-        resp.raise_for_status()
-    except requests.RequestException as e:
-        log_error(f"Ошибка загрузки страницы: {e}", url)
-        return None
-    soup = BeautifulSoup(resp.text, "html.parser")
-    for tag in soup(["script", "style", "noscript"]):
-        tag.extract()
-    texts = [t.get_text(separator=" ", strip=True) for t in soup.find_all(["p","h1","h2","h3"])]
-    text = " ".join(texts) or soup.get_text(separator=" ", strip=True)
-    return text.replace("\xa0", " ")[:limit]
-
-def get_article_content(url, max_attempts=3, text_limit=8000):
-    global last_llm_response
-    if not OPENAI_API_KEY:
-        log_error("OPENAI_API_KEY не задан", url)
-        return "Ошибка: OPENAI_API_KEY не задан", "Ошибка: OPENAI_API_KEY не задан"
-
-    article_text = extract_article_text(url, limit=text_limit)
-    if not article_text:
-        return "Ошибка: не удалось загрузить статью", "Ошибка: не удалось загрузить статью"
-
-    client = OpenAI(api_key=OPENAI_API_KEY)
-    prompt = get_prompt().format(text=article_text)
-    model = get_model()
-
-    for attempt in range(max_attempts):
-        logger.info(f"Запрос к OpenAI для {url}, попытка {attempt+1}, модель: {model}")
-        try:
-            resp = client.chat.completions.create(
-                model=model,
-                messages=[{"role": "user", "content": prompt}],
-                temperature=0.7,
-                max_tokens=500
-            )
-            content = resp.choices[0].message.content.strip()
-            last_llm_response = {"response": content, "link": url, "timestamp": datetime.now().isoformat()}
-
-            if "\n" in content:
-                title, summary = content.split("\n", 1)
-            else:
-                parts = re.split(r'(?<=[.!?])\s+', content)
-                title = parts[0]
-                summary = " ".join(parts[1:]) if len(parts)>1 else "Пересказ не получен"
-
-            title = clean_title(title)
-            if len(title) > 100:
-                title = title[:97] + "..."
-            if is_valid_language(title):
-                return title, summary.strip()
-            else:
-                log_error(f"Недопустимый язык в заголовке: {title}", url)
-        except Exception as e:
-            log_error(f"Ошибка запроса к OpenAI: {e}", url)
-            if attempt == max_attempts-1:
-                return "Ошибка: Не удалось обработать новость после попыток", "Ошибка: Не удалось обработать новость"
-            time.sleep(1)
-
-    return "Ошибка: Не удалось обработать новость после попыток", "Ошибка: Не удалось обработать новость"
-
-def save_to_feedcache(title, summary, link, source):
-    conn = sqlite3.connect(DB_FILE)
-    c = conn.cursor()
-    link_hash = hashlib.md5(link.encode()).hexdigest()
-    c.execute("INSERT OR REPLACE INTO feedcache (id,title,summary,link,source,timestamp) VALUES (?,?,?,?,?,?)",
-              (link_hash, title, summary, link, source, datetime.now().isoformat()))
-    conn.commit()
-    conn.close()
-
-def check_duplicate(link):
-    conn = sqlite3.connect(DB_FILE)
-    c = conn.cursor()
-    link_hash = hashlib.md5(link.encode()).hexdigest()
-    c.execute("SELECT 1 FROM feedcache WHERE id=?", (link_hash,))
-    exists = c.fetchone() is not None
-    conn.close()
-    return exists
-
-def get_channel_by_admin(username):
-    conn = sqlite3.connect(DB_FILE)
-    c = conn.cursor()
-    c.execute("SELECT channel_id FROM admins WHERE username=?", (username,))
-    row = c.fetchone()
-    conn.close()
-    return row[0] if row else None
-
-def get_channel_creator(channel_id):
-    conn = sqlite3.connect(DB_FILE)
-    c = conn.cursor()
-    c.execute("SELECT creator_username FROM channels WHERE channel_id=?", (channel_id,))
-    row = c.fetchone()
-    conn.close()
-    return row[0] if row else None
-
-def save_channel(channel_id, creator_username):
-    conn = sqlite3.connect(DB_FILE)
-    c = conn.cursor()
-    c.execute("INSERT OR IGNORE INTO channels (channel_id, creator_username) VALUES (?, ?)", (channel_id, creator_username))
-    c.execute("INSERT OR IGNORE INTO admins (channel_id, username) VALUES (?, ?)", (channel_id, creator_username))
-    conn.commit()
-    conn.close()
-
-def add_admin(channel_id, new_admin_username, requester_username):
-    conn = sqlite3.connect(DB_FILE)
-    c = conn.cursor()
-    c.execute("SELECT 1 FROM admins WHERE channel_id=? AND username=?", (channel_id, requester_username))
-    if c.fetchone():
-        c.execute("INSERT OR IGNORE INTO admins (channel_id, username) VALUES (?, ?)", (channel_id, new_admin_username))
-        conn.commit()
-        conn.close()
-        return True
-    conn.close()
-    return False
-
-def remove_admin(channel_id, admin_username, requester_username):
-    conn = sqlite3.connect(DB_FILE)
-    c = conn.cursor()
-    c.execute("SELECT 1 FROM admins WHERE channel_id=? AND username=?", (channel_id, requester_username))
-    if c.fetchone():
-        creator = get_channel_creator(channel_id)
-        if admin_username == creator:
-            conn.close()
-            return False
-        c.execute("DELETE FROM admins WHERE channel_id=? AND username=?", (channel_id, admin_username))
-        conn.commit()
-        conn.close()
-        return True
-    conn.close()
-    return False
-
-def get_admins(channel_id):
-    conn = sqlite3.connect(DB_FILE)
-    c = conn.cursor()
-    c.execute("SELECT username FROM admins WHERE channel_id=?", (channel_id,))
-    admins = [r[0] for r in c.fetchall()]
-    conn.close()
-    return admins
-
-def can_post_to_channel(channel_id):
-    global error_count
-    try:
-        me = requests.get(f"{TELEGRAM_URL}getMe", timeout=10)
-        me.raise_for_status()
-        bot_id = me.json()["result"]["id"]
-        resp = requests.get(f"{TELEGRAM_URL}getChatMember",
-                            params={"chat_id": channel_id, "user_id": bot_id}, timeout=10)
-        if resp.status_code == 200:
-            return resp.json()["result"]["status"] in ["administrator", "creator"]
-        log_error(f"Ошибка проверки прав: {resp.text}", channel_id)
-        error_count += 1
-        return False
-    except requests.RequestException as e:
-        log_error(f"Ошибка проверки прав: {e}", channel_id)
-        error_count += 1
-        return False
-
-def parse_interval(interval_str):
-    total_seconds = 0
-    for value, unit in re.findall(r'(\d+)([hm])', interval_str.lower()):
-        v = int(value)
-        if unit == 'h':
-            total_seconds += v * 3600
-        elif unit == 'm':
-            total_seconds += v * 60
-    return total_seconds if total_seconds > 0 else None
-
-def post_news():
-    global current_index, posting_active, post_count, error_count, duplicate_count, last_post_time
-    while posting_active:
-        conn = sqlite3.connect(DB_FILE)
-        c = conn.cursor()
-        c.execute("SELECT channel_id FROM channels")
-        channels = [r[0] for r in c.fetchall()]
-        conn.close()
-
-        if not channels:
-            next_post_event.wait(posting_interval)
-            next_post_event.clear()
-            continue
-
-        rss_url = RSS_URLS[current_index]
-        try:
-            r = requests.get(rss_url, timeout=10); r.raise_for_status()
-            feed = feedparser.parse(r.content)
-        except requests.RequestException as e:
-            log_error(f"Ошибка RSS: {e}", rss_url)
-            error_count += 1
-            current_index = (current_index + 1) % len(RSS_URLS)
-            next_post_event.wait(posting_interval)
-            next_post_event.clear()
-            continue
-
-        if feed.entries:
-            link = feed.entries[0].link
-            if not check_duplicate(link):
-                title, summary = get_article_content(link)
-                if "Ошибка" not in title:
-                    message = f"<b>{title}</b> <a href='{link}'>| Источник</a>\n{summary}\n\n<i>Пост сгенерирован ИИ</i>"
-                    for ch in channels:
-                        if can_post_to_channel(ch) and send_message(ch, message):
-                            save_to_feedcache(title, summary, link, rss_url.split('/')[2])
-                            post_count += 1
-                            last_post_time = time.time()
-                        else:
-                            error_count += 1
-                else:
-                    error_count += 1
-            else:
-                duplicate_count += 1
-
-        current_index = (current_index + 1) % len(RSS_URLS)
-        next_post_event.wait(posting_interval)
-        next_post_event.clear()
-
-def start_posting_thread():
-    global posting_thread, posting_active, start_time
-    if not posting_thread or not posting_thread.is_alive():
-        posting_active = True
-        start_time = time.time()
-        posting_thread = threading.Thread(target=post_news)
-        posting_thread.start()
-
-def stop_posting_thread():
-    global posting_active, posting_thread
-    posting_active = False
-    next_post_event.set()
-    if posting_thread:
-        posting_thread.join()
-        posting_thread = None
-
-def get_status(username):
-    channel_id = get_channel_by_admin(username)
-    uptime = timedelta(seconds=int(time.time() - start_time)) if start_time else "Не запущен"
-    if posting_active and last_post_time:
-        elapsed = time.time() - last_post_time
-        to_next = posting_interval - (elapsed % posting_interval)
-        next_post = f"{int(to_next // 60)} мин {int(to_next % 60)} сек"
-    else:
-        next_post = "Не активно"
-    interval_str = f"{posting_interval//3600}h {((posting_interval%3600)//60)}m" if posting_interval >= 3600 else f"{posting_interval//60}m"
-    admins = get_admins(channel_id) if channel_id else []
-    creator = get_channel_creator(channel_id) if channel_id else "Неизвестен"
-    current_rss = RSS_URLS[current_index] if current_index < len(RSS_URLS) else "Нет"
-    cache_size = sqlite3.connect(DB_FILE).execute("SELECT COUNT(*) FROM feedcache").fetchone()[0]
-    return f"""
-Статус бота:
-Канал: {channel_id}
-Создатель: @{creator}
-Админы: {', '.join('@'+a for a in admins)}
-Состояние постинга: {'Активен' if posting_active else 'Остановлен'}
-Текущий интервал: {interval_str}
-Время до следующего поста: {next_post}
-Текущий RSS: {current_rss}
-Всего RSS-источников: {len(RSS_URLS)}
-Запощенных постов: {post_count}
-Пропущено дублей: {duplicate_count}
-Ошибок: {error_count}
-Размер кэша: {cache_size} записей
-Аптайм: {uptime}
-Текущая модель: {get_model()}
-Текущий промпт:
-{get_prompt()}
-"""
-
-def get_help():
-    return """
-Доступные команды:
-/start - Привязать канал или проверить доступ
-/startposting - Начать постинг
-/stopposting - Остановить постинг
-/setinterval <time> - Установить интервал (34m, 1h, 2h 53m)
-/nextpost - Сбросить таймер и запостить
-/skiprss - Пропустить следующий RSS
-/changellm <model> - Сменить модель LLM (например, gpt-4o-mini)
-/editprompt - Изменить промпт для ИИ (отправь после команды)
-/sqlitebackup - Выгрузить базу SQLite в чат
-/sqliteupdate - Загрузить базу SQLite (отправь файл после команды)
-/info - Показать статус бота
-/errinf - Показать последние ошибки
-/errnotification <on/off> - Включить/выключить уведомления об ошибках
-/feedcache - Показать кэш новостей
-/feedcacheclear - Очистить кэш
-/addadmin <username> - Добавить админа
-/removeadmin <username> - Удалить админа
-/debug - Показать последний сырой ответ LLM
-/help - Это сообщение
-"""
 
 @app.route('/ping', methods=['GET'])
 def ping():
     return "OK", 200
 
+
 @app.route('/webhook', methods=['POST'])
-def webhook():  
+def webhook():
     update = request.get_json()
     if not update or 'message' not in update or 'message_id' not in update['message']:
         return "OK", 200
@@ -526,10 +34,10 @@ def webhook():
     username = message['from'].get('username')
 
     if not username:
-        send_message(chat_id, "У вас нет username. Установите его в настройках Telegram.")
+        tg.send_message(chat_id, "У вас нет username. Установите его в настройках Telegram.")
         return "OK", 200
 
-    user_channel = get_channel_by_admin(username)
+    user_channel = db.get_channel_by_admin(username)
 
     if not text.startswith('/'):
         return "OK", 200
@@ -546,89 +54,87 @@ def webhook():
             channel_id = arg
 
         if user_channel and not channel_id:
-            send_message(chat_id, f"Канал уже привязан: {user_channel}")
+            tg.send_message(chat_id, f"Канал уже привязан: {user_channel}")
         elif channel_id:
-            if can_post_to_channel(channel_id):
-                save_channel(channel_id, username)
-                send_message(chat_id, f"Канал {channel_id} привязан к @{username}")
+            if tg.can_post_to_channel(channel_id):
+                db.save_channel(channel_id, username)
+                tg.send_message(chat_id, f"Канал {channel_id} привязан к @{username}")
             else:
-                send_message(chat_id, "Бот не имеет прав администратора в указанном канале")
+                tg.send_message(chat_id, "Бот не имеет прав администратора в указанном канале")
         else:
-            send_message(chat_id, "Укажите канал командой /start @channel или отправьте команду из канала")
+            tg.send_message(chat_id, "Укажите канал командой /start @channel или отправьте команду из канала")
 
     elif command == '/startposting':
         if not user_channel:
-            send_message(chat_id, "Канал не привязан. Используйте /start в канале")
-        elif posting_active:
-            send_message(chat_id, "Постинг уже запущен")
+            tg.send_message(chat_id, "Канал не привязан. Используйте /start в канале")
+        elif feeds.posting_active:
+            tg.send_message(chat_id, "Постинг уже запущен")
         else:
-            start_posting_thread()
-            send_message(chat_id, "Постинг запущен")
+            feeds.start_posting_thread()
+            tg.send_message(chat_id, "Постинг запущен")
 
     elif command == '/stopposting':
-        if posting_active:
-            stop_posting_thread()
-            send_message(chat_id, "Постинг остановлен")
+        if feeds.posting_active:
+            feeds.stop_posting_thread()
+            tg.send_message(chat_id, "Постинг остановлен")
         else:
-            send_message(chat_id, "Постинг и так не активен")
+            tg.send_message(chat_id, "Постинг и так не активен")
 
     elif command == '/setinterval':
-        seconds = parse_interval(arg)
+        seconds = feeds.parse_interval(arg)
         if seconds:
-            global posting_interval
-            posting_interval = seconds
-            next_post_event.set()
-            send_message(chat_id, f"Интервал обновлён: {arg}")
+            feeds.posting_interval = seconds
+            feeds.next_post_event.set()
+            tg.send_message(chat_id, f"Интервал обновлён: {arg}")
         else:
-            send_message(chat_id, "Неверный формат. Пример: /setinterval 1h 30m")
+            tg.send_message(chat_id, "Неверный формат. Пример: /setinterval 1h 30m")
 
     elif command == '/nextpost':
-        next_post_event.set()
-        send_message(chat_id, "Следующий пост скоро будет опубликован")
+        feeds.next_post_event.set()
+        tg.send_message(chat_id, "Следующий пост скоро будет опубликован")
 
     elif command == '/skiprss':
-        global current_index
-        current_index = (current_index + 1) % len(RSS_URLS)
-        next_post_event.set()
-        send_message(chat_id, "Следующий RSS-источник пропущен")
+        feeds.current_index = (feeds.current_index + 1) % len(feeds.RSS_URLS)
+        feeds.next_post_event.set()
+        tg.send_message(chat_id, "Следующий RSS-источник пропущен")
 
     elif command == '/changellm':
         if arg:
-            set_model(arg)
-            send_message(chat_id, f"Модель изменена на {arg}")
+            db.set_model(arg)
+            tg.send_message(chat_id, f"Модель изменена на {arg}")
         else:
-            send_message(chat_id, "Укажите модель, например /changellm gpt-4o-mini")
+            tg.send_message(chat_id, "Укажите модель, например /changellm gpt-4o-mini")
 
     elif command == '/editprompt':
         if arg:
-            set_prompt(arg)
-            send_message(chat_id, "Промпт обновлён")
+            db.set_prompt(arg)
+            tg.send_message(chat_id, "Промпт обновлён")
         else:
-            send_message(chat_id, "Используйте /editprompt <новый промпт>")
+            tg.send_message(chat_id, "Используйте /editprompt <новый промпт>")
 
     elif command == '/sqlitebackup':
-        send_file(chat_id, DB_FILE)
+        tg.send_file(chat_id, db.DB_FILE)
 
     elif command == '/sqliteupdate':
         if 'document' in message:
             file_id = message['document']['file_id']
-            info = requests.get(f"{TELEGRAM_URL}getFile", params={'file_id': file_id}, timeout=10).json()
+            info = requests.get(f"{tg.TELEGRAM_URL}getFile", params={'file_id': file_id}).json()
             file_path = info.get('result', {}).get('file_path')
             if file_path:
-                file_data = requests.get(f"https://api.telegram.org/file/bot{TELEGRAM_TOKEN}/{file_path}", timeout=10)
-                with open(DB_FILE, 'wb') as f:
+                file_data = requests.get(f"https://api.telegram.org/file/bot{tg.TELEGRAM_TOKEN}/{file_path}")
+                with open(db.DB_FILE, 'wb') as f:
                     f.write(file_data.content)
-                send_message(chat_id, "База обновлена")
+                tg.send_message(chat_id, "База обновлена")
             else:
-                send_message(chat_id, "Не удалось получить файл")
+                tg.send_message(chat_id, "Не удалось получить файл")
         else:
-            send_message(chat_id, "Отправьте SQLite файл как документ с подписью /sqliteupdate")
+            tg.send_message(chat_id, "Отправьте SQLite файл как документ с подписью /sqliteupdate")
 
     elif command == '/info':
-        send_message(chat_id, get_status(username))
+        tg.send_message(chat_id, feeds.get_status(username))
 
     elif command == '/errinf':
-        conn = sqlite3.connect(DB_FILE)
+        conn = sqlite3.connect(db.DB_FILE)
         c = conn.cursor()
         c.execute("SELECT timestamp, message, link FROM errors ORDER BY id DESC LIMIT 5")
         rows = c.fetchall()
@@ -637,17 +143,17 @@ def webhook():
             msg = '\n\n'.join(f"{t}\n{m}\n{l}" for t, m, l in rows)
         else:
             msg = "Ошибок нет"
-        send_message(chat_id, msg, use_html=False)
+        tg.send_message(chat_id, msg, use_html=False)
 
     elif command == '/errnotification':
         if arg in ['on', 'off']:
-            set_error_notifications(arg)
-            send_message(chat_id, f"Уведомления об ошибках: {arg}")
+            db.set_error_notifications(arg)
+            tg.send_message(chat_id, f"Уведомления об ошибках: {arg}")
         else:
-            send_message(chat_id, "Использование: /errnotification <on|off>")
+            tg.send_message(chat_id, "Использование: /errnotification <on|off>")
 
     elif command == '/feedcache':
-        conn = sqlite3.connect(DB_FILE)
+        conn = sqlite3.connect(db.DB_FILE)
         c = conn.cursor()
         c.execute("SELECT title, link FROM feedcache ORDER BY timestamp DESC LIMIT 5")
         rows = c.fetchall()
@@ -656,50 +162,51 @@ def webhook():
             msg = '\n\n'.join(f"{t}\n{l}" for t, l in rows)
         else:
             msg = "Кэш пуст"
-        send_message(chat_id, msg, use_html=False)
+        tg.send_message(chat_id, msg, use_html=False)
 
     elif command == '/feedcacheclear':
-        conn = sqlite3.connect(DB_FILE)
+        conn = sqlite3.connect(db.DB_FILE)
         conn.execute("DELETE FROM feedcache")
         conn.commit()
         conn.close()
-        send_message(chat_id, "Кэш очищен")
+        tg.send_message(chat_id, "Кэш очищен")
 
     elif command == '/addadmin':
         if not user_channel:
-            send_message(chat_id, "Канал не привязан")
+            tg.send_message(chat_id, "Канал не привязан")
         elif arg:
-            if add_admin(user_channel, arg.lstrip('@'), username):
-                send_message(chat_id, f"Админ {arg} добавлен")
+            if db.add_admin(user_channel, arg.lstrip('@'), username):
+                tg.send_message(chat_id, f"Админ {arg} добавлен")
             else:
-                send_message(chat_id, "Не удалось добавить админа")
+                tg.send_message(chat_id, "Не удалось добавить админа")
         else:
-            send_message(chat_id, "Использование: /addadmin <username>")
+            tg.send_message(chat_id, "Использование: /addadmin <username>")
 
     elif command == '/removeadmin':
         if not user_channel:
-            send_message(chat_id, "Канал не привязан")
+            tg.send_message(chat_id, "Канал не привязан")
         elif arg:
-            if remove_admin(user_channel, arg.lstrip('@'), username):
-                send_message(chat_id, f"Админ {arg} удалён")
+            if db.remove_admin(user_channel, arg.lstrip('@'), username):
+                tg.send_message(chat_id, f"Админ {arg} удалён")
             else:
-                send_message(chat_id, "Не удалось удалить админа")
+                tg.send_message(chat_id, "Не удалось удалить админа")
         else:
-            send_message(chat_id, "Использование: /removeadmin <username>")
+            tg.send_message(chat_id, "Использование: /removeadmin <username>")
 
     elif command == '/debug':
         if last_llm_response:
-            send_message(chat_id, json.dumps(last_llm_response, ensure_ascii=False), use_html=False)
+            tg.send_message(chat_id, json.dumps(last_llm_response, ensure_ascii=False), use_html=False)
         else:
-            send_message(chat_id, "Нет сохранённого ответа LLM")
+            tg.send_message(chat_id, "Нет сохранённого ответа LLM")
 
     elif command == '/help':
-        send_message(chat_id, get_help())
+        tg.send_message(chat_id, feeds.get_help())
 
     else:
-        send_message(chat_id, "Неизвестная команда. Используйте /help")
+        tg.send_message(chat_id, "Неизвестная команда. Используйте /help")
 
     return "OK", 200
 
-if __name__ == "__main__":
-    app.run(host="0.0.0.0", port=5000)
+
+if __name__ == '__main__':
+    app.run(host='0.0.0.0', port=5000)


### PR DESCRIPTION
## Summary
- shrink `bot.py` to a minimal entry point
- reuse existing helpers from `telegram_api`, `database`, `feeds`, and `llm`

## Testing
- `python -m py_compile bot.py feeds.py llm.py database.py telegram_api.py`


------
https://chatgpt.com/codex/tasks/task_e_684479c6cc7c832a882fa180705dee4d