### PR TITLE
Fix feedcache count connection usage

### DIFF
--- a/feeds.py
+++ b/feeds.py
@@ -154,7 +154,8 @@ def get_status(username: str) -> str:
     current_rss = RSS_URLS[current_index] if current_index < len(RSS_URLS) else "Нет"
     prompt = get_prompt()
     current_model = get_model()
-    feedcache_size = sqlite3.connect(DB_FILE).execute("SELECT COUNT(*) FROM feedcache").fetchone()[0]
+    with sqlite3.connect(DB_FILE) as conn:
+        feedcache_size = conn.execute("SELECT COUNT(*) FROM feedcache").fetchone()[0]
     return f"""Статус бота:
 Канал: {channel_id}
 Создатель: @{creator}


### PR DESCRIPTION
## Summary
- use a context manager when counting feedcache records in `feeds.get_status`

## Testing
- `python -m py_compile database.py feeds.py bot.py telegram_api.py llm.py`

------
https://chatgpt.com/codex/tasks/task_e_6844922f7430832abb31e26bee8de2fb