### PR TITLE
Add parse_interval tests

### DIFF
--- a/tests/test_parse_interval.py
+++ b/tests/test_parse_interval.py
@@ -1,0 +1,20 @@
+import sys
+from pathlib import Path
+import pytest
+
+# Ensure repository root is on the import path so ``feeds`` resolves to the
+# local module rather than any installed package with the same name.
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from feeds import parse_interval
+
+@pytest.mark.parametrize(
+    "text,expected",
+    [
+        ("1h", 3600),
+        ("2h 30m", 9000),
+        ("40m", 2400),
+    ],
+)
+def test_parse_interval(text, expected):
+    assert parse_interval(text) == expected


### PR DESCRIPTION
## Summary
- add pytest module for `parse_interval` examples

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68449a1da248832aa3258c12479667a0